### PR TITLE
fix: integrate wit new clap driver

### DIFF
--- a/rviz2_plugin_examples/CMakeLists.txt
+++ b/rviz2_plugin_examples/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(rviz_2d_overlay_plugins REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
 find_package(builtin_interfaces REQUIRED)
 find_package(tier4_debug_msgs REQUIRED)
-find_package(rbf_clap_b7_msgs REQUIRED)
+find_package(clap_b7_driver REQUIRED)
 
 include_directories(
         include
@@ -46,7 +46,7 @@ ament_target_dependencies(plugin_example
         rviz_2d_overlay_plugins
         sensor_msgs
         tier4_debug_msgs
-        rbf_clap_b7_msgs
+        clap_b7_driver
         )
 
 

--- a/rviz2_plugin_examples/include/rviz2_plugin_examples/PluginExample.h
+++ b/rviz2_plugin_examples/include/rviz2_plugin_examples/PluginExample.h
@@ -18,7 +18,8 @@
 #include "pie_chart_display.h"
 
 #include <tier4_debug_msgs/msg/float32_stamped.hpp>
-#include <rbf_clap_b7_msgs/msg/ins_data.hpp>
+#include <clap_b7_driver/msg/clap_ins.hpp>
+
 
 #include "math.h"
 
@@ -38,11 +39,11 @@ private:
 
     rclcpp::Subscription<tier4_debug_msgs::msg::Float32Stamped>::SharedPtr ndt_sub;
     rclcpp::Subscription<sensor_msgs::msg::NavSatFix>::SharedPtr gnss_sub;
-    rclcpp::Subscription<rbf_clap_b7_msgs::msg::InsData>::SharedPtr rtk_sub;
+    rclcpp::Subscription<clap_b7_driver::msg::ClapIns>::SharedPtr rtk_sub;
 
     void ndt_callback(const tier4_debug_msgs::msg::Float32Stamped::SharedPtr msg);
     void gnss_callback(const sensor_msgs::msg::NavSatFix::SharedPtr msg);
-    void rtk_callback(const rbf_clap_b7_msgs::msg::InsData::SharedPtr msg);
+    void rtk_callback(const clap_b7_driver::msg::ClapIns::SharedPtr msg);
 };
 
 

--- a/rviz2_plugin_examples/package.xml
+++ b/rviz2_plugin_examples/package.xml
@@ -14,7 +14,7 @@
   <depend>std_msgs</depend>
   <depend>tier4_autoware_utils</depend>
   <depend>tier4_debug_msgs</depend>
-  <depend>rbf_clap_b7_msgs</depend>
+  <depend>clap_b7_driver</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>rviz_2d_overlay_msgs</exec_depend>

--- a/rviz2_plugin_examples/src/PluginExample.cpp
+++ b/rviz2_plugin_examples/src/PluginExample.cpp
@@ -219,7 +219,7 @@ void PluginExample::gnss_callback(const sensor_msgs::msg::NavSatFix::SharedPtr m
 
 }
 
-void PluginExample::rtk_callback(const rbf_clap_b7_msgs::msg::InsData::SharedPtr msg) {
+void PluginExample::rtk_callback(const clap_b7_driver::msg::ClapIns::SharedPtr msg) {
     std_msgs::msg::ColorRGBA color;
     std_msgs::msg::ColorRGBA color_bg;
     color_bg.r = 1.0f;

--- a/rviz2_plugin_examples/src/PluginExample.cpp
+++ b/rviz2_plugin_examples/src/PluginExample.cpp
@@ -21,8 +21,8 @@ PluginExample::PluginExample() : Node("plugin_example") {
     gnss_sub = create_subscription<sensor_msgs::msg::NavSatFix>(
             "/sensing/gnss/clap/ros/gps_nav_sat_fix", 100,
             std::bind(&PluginExample::gnss_callback, this, std::placeholders::_1));
-    rtk_sub = create_subscription<rbf_clap_b7_msgs::msg::InsData>(
-            "/sensing/gnss/clap/clap_msgs/clap_ins", 100,
+    rtk_sub = create_subscription<clap_b7_driver::msg::ClapIns>(
+            "/sensing/gnss/clap/clap_ins", 100,
             std::bind(&PluginExample::rtk_callback, this, std::placeholders::_1));
 }
 


### PR DESCRIPTION
## Description

Integrated with new CLAP driver.

## Tests performed

I used plugins while I'm testing RobiOne's pose initializing limits.

## Effects on system behavior

Plugin. can work with new CLAP driver now

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
